### PR TITLE
Fix to Safari Proxy bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "floating-vue-monorepo",
   "packageManager": "pnpm@8.6.2",
-  "version": "2.0.0-beta.24",
+  "version": "2.0.0-reedsy.1.0.2",
   "private": true,
   "scripts": {
     "build": "pnpm -r --filter=\"./packages/*\" run build",

--- a/packages/floating-vue/package.json
+++ b/packages/floating-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/floating-vue",
-  "version": "2.0.0-reedsy.1.0.1",
+  "version": "2.0.0-reedsy.1.0.2",
   "description": "Easy Vue tooltips, dropdowns, menus & popovers using floating-ui",
   "author": "Guillaume Chau <guillaume.b.chau@gmail.com>",
   "scripts": {

--- a/packages/floating-vue/src/components/Popper.ts
+++ b/packages/floating-vue/src/components/Popper.ts
@@ -450,7 +450,7 @@ export default () => defineComponent({
       if (this.$_hideInProgress) return
 
       // Abort if child is shown
-      if (this.shownChildren.size > 0) {
+      if (new Set(this.shownChildren).size > 0) {
         this.$_pendingHide = true
         return
       }
@@ -684,7 +684,7 @@ export default () => defineComponent({
     },
 
     $_scheduleHide (event = null, skipDelay = false) {
-      if (this.shownChildren.size > 0) {
+      if (new Set(this.shownChildren).size > 0) {
         this.$_pendingHide = true
         return
       }
@@ -788,7 +788,7 @@ export default () => defineComponent({
     },
 
     async $_applyHide (skipTransition = false) {
-      if (this.shownChildren.size > 0) {
+      if (new Set(this.shownChildren).size > 0) {
         this.$_pendingHide = true
         this.$_hideInProgress = false
         return


### PR DESCRIPTION
Fixes occasional Safari bug that causes a break in Vue if using Set. There doesn't seem to be a reliable way to recreate it, closest I got was opening and closing dev tools while the app is loading but the timing is very strict and inconsistent.

This setup:

```tsx
data() {
  return {
    foo: new Set(),
  }
},
mounted() {
  console.log(this.foo.size);
}
```

results in:

![Untitled](https://github.com/reedsy/floating-vue/assets/41785864/efdbe17c-e8e3-46e5-8928-413550276d91)

- First [log](https://github.com/vuejs/core/blob/a09ed44446cdcc8a0a49c2dda9358a30af0b1f5f/packages/reactivity/src/collectionHandlers.ts#L348): `target`, `key`, and `receiver`
- Second [log](https://github.com/vuejs/core/blob/a09ed44446cdcc8a0a49c2dda9358a30af0b1f5f/packages/reactivity/src/collectionHandlers.ts#L236): `this`
- Third [log](https://github.com/vuejs/core/blob/a09ed44446cdcc8a0a49c2dda9358a30af0b1f5f/packages/reactivity/src/collectionHandlers.ts#L63): `target` 
- [Errors](https://github.com/vuejs/core/blob/a09ed44446cdcc8a0a49c2dda9358a30af0b1f5f/packages/reactivity/src/collectionHandlers.ts#L66)

Seems like a Safari issue that on `Reflect.get` it turns the `receiver` Proxy into an object. Then it fails as `target` gets redefined assuming it’s a Proxy, and this returns `undefined` which errors when passed into `Reflect.get`.

This is the least disruptive fix to the bug, as we no longer rely on the Vue Proxy when checking size of `Set`.